### PR TITLE
Fixes #1 - Make useBehaviours prop optional

### DIFF
--- a/packages/core/src/Tei.astro
+++ b/packages/core/src/Tei.astro
@@ -3,7 +3,7 @@ import processTei from "./processTei";
 
 export interface Props {
   data: string;
-  useBehaviors: boolean;
+  useBehaviors?: boolean;
 }
 
 let { data, useBehaviors = true } = Astro.props as Props;


### PR DESCRIPTION
In the `astro-tei` demo `index.astro`, the rendered <Tei/> component expects a useBehaviors prop that is currently not set, which results in a Typescript error.

This is a possible fix by making the prop optional as it already has a default value set.

Issue: https://github.com/raffazizzi/astro-tei/issues/1